### PR TITLE
Let conda determine python_min and allow for python >= python_min

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -7,7 +7,7 @@ context:
   #
   # Minimum version of python on conda-forge.  This should be set automatically 
   # by conda-forge and should only be uncommented for local testing.
-  python_min: "3.10"
+  # python_min: "3.10"
 
 package:
   name: ${{ name }}
@@ -24,7 +24,7 @@ source:
 
 build:
   # First build number for each version is 0
-  number: 0
+  number: 1
   #
   # rattler-build does not handle python install scripts properly.
   python:
@@ -41,7 +41,7 @@ requirements:
     - cmake
     - ninja
   host:
-    - python =${{ python_min }}
+    - python >=${{ python_min }}
     - pip
     - setuptools
     - pkg-config
@@ -52,7 +52,7 @@ requirements:
     - matplotlib-base
     - scipy
   run:
-    - python =${{ python_min }}
+    - python >=${{ python_min }}
     - numpy
     - matplotlib-base
     - scipy
@@ -65,7 +65,7 @@ tests:
       file: run_test.py
     requirements:
       run:
-        - python =${{ python_min }}
+        - python >=${{ python_min }}
         - numpy
         - matplotlib
         - scipy

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -41,7 +41,7 @@ requirements:
     - cmake
     - ninja
   host:
-    - python >=${{ python_min }}
+    - python
     - pip
     - setuptools
     - pkg-config
@@ -52,7 +52,7 @@ requirements:
     - matplotlib-base
     - scipy
   run:
-    - python >=${{ python_min }}
+    - python
     - numpy
     - matplotlib-base
     - scipy
@@ -65,7 +65,7 @@ tests:
       file: run_test.py
     requirements:
       run:
-        - python >=${{ python_min }}
+        - python
         - numpy
         - matplotlib
         - scipy


### PR DESCRIPTION
2. Allow for any python >= python_min.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x ] Bumped the build number (if the version is unchanged)
* [x ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
