### PR TITLE
Force rebuild for python 3.14 (no autobot for it).

### DIFF
--- a/recipe/2026.0.1.patch
+++ b/recipe/2026.0.1.patch
@@ -1,0 +1,23 @@
+diff --git a/python/pyproject.toml b/python/pyproject.toml
+index e69c25c1a..c203fa12e 100644
+--- a/python/pyproject.toml
++++ b/python/pyproject.toml
+@@ -13,7 +13,7 @@ name              = 'dismod_at'
+ version           = '2026.0.1'
+ description       = 'Disease Rates as Functions of Age and Time'
+ readme            = 'README.md'
+-requires-python   = '>=3.0'
++requires-python   = '>=3.10'
+ keywords          = [ 'public health', 'disease', 'cause of death' ]
+ authors           = [
+   {name  = 'Bradley M. Bell', email = 'bradbell@seanet.com'},
+@@ -33,7 +33,8 @@ classifiers       = [
+ ]
+ #
+ # https://github.com/pypa/setuptools/issues/4903
+-license           = { text = 'AGPL-3.0-or-later' }
++# license           = { text = 'AGPL-3.0-or-later' }
++license = 'AGPL-3.0-or-later'
+ #
+ # -----------------------------------------------------------------------------
+ [tool.setuptools]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -4,10 +4,6 @@ context:
   name: dismod-at
   version: "2026.0.1"
   cppad_mixed_minimum: "2026.0.0"
-  #
-  # Minimum version of python on conda-forge.  This should be set automatically 
-  # by conda-forge and should only be uncommented for local testing.
-  # python_min: "3.10"
 
 package:
   name: ${{ name }}
@@ -20,11 +16,11 @@ source:
   #
   patches:
     # patches for this version. 
-    # - ${{ version }}.patch
+    - ${{ version }}.patch
 
 build:
   # First build number for each version is 0
-  number: 1
+  number: 2
   #
   # rattler-build does not handle python install scripts properly.
   python:


### PR DESCRIPTION
2. patch to fix warning about license as TOML table is deprecated.
3. Remove reference to python_min.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x ] Bumped the build number (if the version is unchanged)
* [x ] Reset the build number to `0` (if the version changed)
* [x ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
