### PR TITLE
Strawman: Use `python: version_independent`

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_is_python_mintrue:
+        CONFIG: linux_64_is_python_mintrue
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: macOS-15
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_is_python_mintrue:
+        CONFIG: osx_64_is_python_mintrue
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_:
-        CONFIG: win_64_
+      win_64_is_python_mintrue:
+        CONFIG: win_64_is_python_mintrue
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_is_python_mintrue.yaml
+++ b/.ci_support/linux_64_is_python_mintrue.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+is_python_min:
+- true
 numpy:
 - '2'
 python_min:

--- a/.ci_support/osx_64_is_python_mintrue.yaml
+++ b/.ci_support/osx_64_is_python_mintrue.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+is_python_min:
+- true
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/win_64_is_python_mintrue.yaml
+++ b/.ci_support/win_64_is_python_mintrue.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
+is_python_min:
+- true
 numpy:
 - '2'
 python_min:

--- a/README.md
+++ b/README.md
@@ -31,24 +31,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_is_python_mintrue</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dismod-at-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dismod-at-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_is_python_mintrue" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>osx_64_is_python_mintrue</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dismod-at-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dismod-at-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_is_python_mintrue" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64</td>
+              <td>win_64_is_python_mintrue</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dismod-at-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/dismod-at-feedstock?branchName=main&jobName=win&configuration=win%20win_64_is_python_mintrue" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,7 +20,7 @@ source:
 
 build:
   # First build number for each version is 0
-  number: 2
+  number: 3
   skip: not is_python_min
   #
   # rattler-build does not handle python install scripts properly.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,16 +15,18 @@ source:
   sha256: e157312ede3beefbd24b2544c677a73d34b10a05246fac1111e1de039cf7e35a
   #
   patches:
-    # patches for this version. 
+    # patches for this version.
     - ${{ version }}.patch
 
 build:
   # First build number for each version is 0
   number: 2
+  skip: not is_python_min
   #
   # rattler-build does not handle python install scripts properly.
   python:
-    # rattler-build does properly not handle [project.scripts] in 
+    version_independent: true
+    # rattler-build does properly not handle [project.scripts] in
     # pyproject.toml on windows unless they are also listed as entry_points.
     entry_points:
       - dismod-at = dismod_at:main
@@ -37,18 +39,18 @@ requirements:
     - cmake
     - ninja
   host:
-    - python
+    - python ${{ python_min }}.*
     - pip
     - setuptools
     - pkg-config
-    - cppad-mixed >= ${{ cppad_mixed_minimum }}
+    - cppad-mixed >=${{ cppad_mixed_minimum }}
     - sqlite
     - eigen
     - numpy
     - matplotlib-base
     - scipy
   run:
-    - python
+    - python >=${{ python_min }}
     - numpy
     - matplotlib-base
     - scipy
@@ -56,12 +58,18 @@ requirements:
     - ${{ pin_subpackage(name, upper_bound='x.x') }}
 
 tests:
+  - python:
+      imports: dismod_at
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - 3.14.*
   - script:
       interpreter: python
       file: run_test.py
     requirements:
       run:
-        - python
+        - python ${{ python_min }}.*
         - numpy
         - matplotlib
         - scipy


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Changes:
- [x] add `build/python/version_independent: true`
- [x] add `skip: not is_python_min`
- [x] use `python_min` in `host` and `run` deps  
- [x] add `pip check` (and `import`) for the `python_min` and 
- [x] remove some whitespace